### PR TITLE
Fixed problem with `android` not being accessible for some views

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ startTour(){
 
 see the demo project for more info.
 
-## Angular
+### Angular
 also in angular you can get a refrence to the target view using ```@ViewChild``` decorator as next
 ```html
 <Label #feat1 text="Feature 1"></Label>
@@ -111,9 +111,69 @@ startTour(){
 }
 ```
 
+### Vue
+While for Angular the {N} view representations of a referenced ViewChild is in the `.nativeElement` property, the naming in {N}-vue is a little confusing, since the {N} view of a referenced child is in `.nativeView`. Meaning that:
+- `this.$ref.feat1` return the vue view of the child object
+- `this.$ref.feat1.nativeView` returns the {N} view, **which we need to pass as a `stop.view`**
+- (`this.$ref.feat1.nativeView.nativeView` returns the _actual_ native view)
+```html
+<Label ref="feat1" text="Feature 1"></Label>
+<Label ref="feat2" text="Feature 2"></Label>
+<Button text="start" @tap="startTour"></Button>
+```
+
+```
+startTour(){
+
+    const stops = [
+        {
+            view: this.$ref.feat1.nativeView,
+            title: 'Feature 1',
+            description: "Feature 1 Description",
+            dismissable: true
+        },
+        {
+            view: this.$ref.feat2.nativeView,
+            title: 'Feature 2',
+            description: 'Feature 2 Description',
+            outerCircleColor: 'orange',
+            rippleColor: 'black'
+        }
+    ];
+
+    const handlers = {
+        finish() {
+            console.log('Tour finished');
+        },
+        onStep(lastStopIndex) {
+            console.log('User stepped', lastStopIndex);
+        },
+        onCancel(lastStopIndex) {
+            console.log('User cancelled', lastStopIndex);
+        }
+    }
+
+    this.tour = new AppTour(stops, handlers);
+    this.tour.show();
+}
+```
+
+### Special cases on Android (ActionBar, TabView)
+There are some special {N} UI Elements that cannot be accessed by simply using the {N} view of these objects, because it will result in an error `Cannot convert object to Landroid/view/View`.
+
+An example for that is `<ActionBar>` and `<ActionItem>`. To access these, one has to find the nativeView by searching the right child of a referenced objects parent:
+
+```
+const stops = [{
+    view: page.getViewById("actionItem").parent.nativeView.getChildAt(0).getChildAt(0),
+    title: "Action Item",
+    description: "Some Description"
+}]
+```
+This is similar for `<TabView>` and `<TabViewItem>` and might also be for other special items.
 ## API
 
-## TourStop
+### TourStop
 |Param| Description | type | default |
 |---|---|---|---|
 | view (required) | nativescript view ref | View | none |
@@ -130,14 +190,14 @@ startTour(){
 | innerCircleRadius|circle around target view raduis| number| 50|
 | dismissable| can the tour canceled by taping outside of target view | boolean| false|
 
-## AppTour
+### AppTour
 |Method| Description |
 |---|---|
 |constructor | AppTour(stops) |
 |show() | start the tour|
 |reset()| reset the tour to play it again|
 
-## Tour Events
+### Tour Events
 
 This plugin has 3 events,
 finish(): void => triggered once the tour finishes

--- a/src/app-tour.android.ts
+++ b/src/app-tour.android.ts
@@ -11,8 +11,7 @@ export class AppTour extends AppTourBase {
     buildNativeTour(stops: TourStop[], handlers) {
         const targets: any[] = stops.map(stop => {
             this.currentStop = 0;
-
-            return TapTarget.forView(stop.view.android, stop.title, stop.description|| this.defaults.description)
+            return TapTarget.forView(stop.view.nativeView || stop.view.android || stop.view, stop.title, stop.description|| this.defaults.description)
                 .outerCircleColorInt(new Color(stop.outerCircleColor|| this.defaults.outerCircleColor).android)
                 .outerCircleAlpha(float(stop.outerCircleOpacity|| this.defaults.outerCircleOpacity))
                 .targetCircleColorInt(new Color(stop.innerCircleColor|| this.defaults.innerCircleColor).android)

--- a/src/app-tour.common.ts
+++ b/src/app-tour.common.ts
@@ -1,5 +1,5 @@
 export interface TourStop {
-    view: { ios, android };
+    view: { ios, android, nativeView, actionView };
     title: string;
     titleTextSize?: number;
     titleTextColor?: string;

--- a/src/app-tour.common.ts
+++ b/src/app-tour.common.ts
@@ -1,5 +1,5 @@
 export interface TourStop {
-    view: { ios, android, nativeView, actionView };
+    view: { ios, android, nativeView };
     title: string;
     titleTextSize?: number;
     titleTextColor?: string;


### PR DESCRIPTION
NativeScript now uses `nativeView` to access the native views on both iOS and Android, which makes the usage of `.ios` and `.android` deprecated when creating `TapTarget`  and `MaterialShowcase`. On Android it sometimes also leads to problems when `android` is not a property anymore, which is true for some {N} views, might be similar for iOS.

I was only able to test it for Android, therefore I only applied the change to the `app-tour.android.ts`.

Additionally since I had some learning on the usage of the package both on {N}-vue and with special objects like `<ActionBar>` I also added some of these learnings to the README for other developers, who might run into similar problems.